### PR TITLE
New twitter handle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Bug Bounty Journal - Highlights, lowlights and a lot of learning.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://enfinlay.github.io/" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: MurmurPanda
+twitter_username: InfoSecP4nda
 github_username:  EnFinlay
 
 # Build settings


### PR DESCRIPTION
You've changed your twitter handle, totally just prevented you from a deadly social media account takeover attack.